### PR TITLE
Update makefile to create .so

### DIFF
--- a/determination/TRIAD/triad.c
+++ b/determination/TRIAD/triad.c
@@ -12,7 +12,6 @@
 #include "determination/TRIAD/triad.h"
 #include "adcs_math/vector.h"
 #include "adcs_math/matrix.h"
-#include "determination/TRIAD/triad.h"
 
 
 triad_run_status
@@ -25,9 +24,9 @@ triad(
 ) {
 	vec3 bod_basis1 = bod_mag;
 
-  if (vec_norm(bod_basis1, &bod_basis1) < 0) {
-      return TRIAD_NORM_FAILURE;
-  }
+	if (vec_norm(bod_basis1, &bod_basis1) < 0) {
+		return TRIAD_NORM_FAILURE;
+	}
 
 	vec3 bod_basis2;
 	vec_cross(bod_mag, bod_sun, &bod_basis2);
@@ -86,8 +85,3 @@ triad(
 
     return TRIAD_SUCCESS;
 }
-
-
-
-
-

--- a/determination/determination.h
+++ b/determination/determination.h
@@ -1,6 +1,3 @@
-#ifndef DETERMINATION_H
-#define DETERMINATION_H
-
 #include "adcs_math/vector.h"
 
 #ifndef DETERMINATION_H

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC := gcc
-CFLAGS := -I. -lm -Wswitch
+CFLAGS := -I. -lm -shared -Wswitch -fpic
 
 # Source files
 SOURCES := determination/determination.c determination/IGRF_C/igrf.c determination/TRIAD/triad.c \
@@ -9,10 +9,10 @@ SOURCES := determination/determination.c determination/IGRF_C/igrf.c determinati
            determination/novasc3.1/novas.c determination/novasc3.1/novascon.c \
            determination/novasc3.1/solsys1.c determination/novasc3.1/eph_manager.c \
            determination/novasc3.1/readeph0.c determination/pos_lookup/ECEF_to_geodetic.c \
-           determination/novasc3.1/nutation.c main.c
+           determination/novasc3.1/nutation.c
 
 # Target executable name
-TARGET := altitude_determination
+TARGET := libADCS.so
 
 all: $(TARGET)
 


### PR DESCRIPTION
Compile project to a shared object library instead of an executable.
This makes more sense because the ADCS code doesn't actually have
a main function. Instead, the FSW code will need to call functions from
our ADCS 'library' in the form of the .so.