### PR TITLE
Add sensor/actuator choice to virtual intellisat functions

### DIFF
--- a/ADCS.c
+++ b/ADCS.c
@@ -23,6 +23,9 @@ ADCS_MAIN(adcs_mode mode) {
                     break;
                 case DETUMBLING_SUCCESS:
                     break;
+
+                case COILS_TESTING_SUCCESS: //noop
+                case COILS_TESTING_FAILURE: //noop
             }
             break;
         case ADCS_COILS_TESTING:
@@ -32,6 +35,9 @@ ADCS_MAIN(adcs_mode mode) {
                     break;
                 case COILS_TESTING_SUCCESS:
                     break;
+
+                case DETUMBLING_SUCCESS: //noop
+                case DETUMBLING_FAILURE: //noop
             }
             break;
         case ADCS_HDD_EXP_ANGVEL:

--- a/adcs_math/sensors.c
+++ b/adcs_math/sensors.c
@@ -4,7 +4,7 @@ float lowpass_filter(float currValue, float prevValue, float filterConstant) {
     return ((1-filterConstant) * currValue) + (filterConstant * prevValue);
 }
 
-float get_sensor_calibration(vi_sensors sensor, float currValue, float prevValue, float offset, float gain, float filterConstant)
+float get_sensor_calibration(vi_sensor sensor, float currValue, float prevValue, float offset, float gain, float filterConstant)
 {
     int year, month, day, hour, minute, second;
     vi_get_epoch(&year, &month, &day, &hour, &minute, &second);

--- a/adcs_math/sensors.h
+++ b/adcs_math/sensors.h
@@ -46,7 +46,7 @@ float lowpass_filter(float currValue, float prevValue, float filterConstant);
  * 
  * @return sensor calibration value after filtration 
 */
-float get_sensor_calibration(vi_sensors sensor, float currValue, float prevValue, float offset, float gain, float filterConstant);
+float get_sensor_calibration(vi_sensor sensor, float currValue, float prevValue, float offset, float gain, float filterConstant);
 
 /**
  * @brief safely calculate delta_t accounting for integer overflow
@@ -61,7 +61,7 @@ int get_delta_t(int currTime, int prevTime);
 /**
  * @brief Generate a permutation of active sensors.:qa
  */
-char get_alternation(vi_sensors sensor, unsigned int generation);
+char get_alternation(vi_sensor sensor, unsigned int generation);
 
 #endif
 

--- a/control/detumble/detumble.c
+++ b/control/detumble/detumble.c
@@ -15,7 +15,11 @@
 
 #include <math.h>
 
+//TODO: IMU, HDD alternation?
+#define MAG_CHOICE MAG1
+
 const double control_constant = 67200.0; //TODO: tune :p
+
 
 /**@brief find the angular velocity through change in magnetic vector
  * 
@@ -96,7 +100,7 @@ detumble_status detumble(vec3 needle, bool isTesting)
 	startTime = curr_millis;
 
 	//Get current magnetic field reading
-	if(vi_get_mag(&(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
+	if(vi_get_mag(MAG_CHOICE, &(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
 	{
 	    if (isTesting) return COILS_TESTING_FAILURE;
 	    else return DETUMBLING_FAILURE;
@@ -113,7 +117,7 @@ detumble_status detumble(vec3 needle, bool isTesting)
 	{
 		mag_prev = mag;
 		//Get new magnectic field reading
-		if(vi_get_mag(&(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
+		if(vi_get_mag(MAG_CHOICE, &(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
     	{
 			if (isTesting) return COILS_TESTING_FAILURE;
 			else return DETUMBLING_FAILURE;
@@ -127,7 +131,7 @@ detumble_status detumble(vec3 needle, bool isTesting)
 			else return DETUMBLING_FAILURE;
     	}
 		
-		if(vi_get_mag(&(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
+		if(vi_get_mag(MAG_CHOICE, &(mag.x), &(mag.y), &(mag.z)) == VI_GET_MAG_FAILURE)
     	{
 			if (isTesting) return COILS_TESTING_FAILURE;
 			else return DETUMBLING_FAILURE;
@@ -160,9 +164,7 @@ detumble_status detumble(vec3 needle, bool isTesting)
     	int timeElapsed = curr_millis - startTime;
 		bool timeout = timeElapsed > LIMIT;
     	keepDetumbling = aboveThreshold(angVel, 0.5) && !timeout;
-      
 	}
-
 
 	return DETUMBLING_SUCCESS;
 }

--- a/control/experiment/PID_experiment.c
+++ b/control/experiment/PID_experiment.c
@@ -1,10 +1,18 @@
-#include "PID_experiment.h"
+#include "control/experiment/PID_experiment.h"
+#include "virtual_intellisat.h"
+
+#include <math.h>
+
+//TODO: IMU, HDD alternation?
+#define IMU_CHOICE IMU1
+#define HDD_CHOICE HDD1
+
 
 PID_status PID_experiment()
 {
     //Get current angular velocity for z axis
     double angvel_x = 0, angvel_y = 0, angvel_z = 0;
-    if(vi_get_angvel(&angvel_x, &angvel_y, &angvel_z) == GET_ANGVEL_FAILURE)
+    if(vi_get_angvel(IMU_CHOICE, &angvel_x, &angvel_y, &angvel_z) == GET_ANGVEL_FAILURE)
         return PID_EXPERIMENT_FAILURE;
 
     //Get the current time (Virtual Intellisat)
@@ -18,7 +26,7 @@ PID_status PID_experiment()
     PID_init(target, angvel_z, curr_millis, 1, 1, 1, &controller);
     
     //Run a while loop 
-    while (abs(target - angvel_z) > 0.1)
+    while (fabs(target - angvel_z) > 0.1)
     {
         //Get the current time (Virtual Intellisat)
         if(vi_get_curr_millis(&curr_millis) == GET_CURR_MILLIS_FAILURE)
@@ -28,7 +36,7 @@ PID_status PID_experiment()
         double throttle = PID_command(target, angvel_z, curr_millis, &controller);
 
         //Take output and plug it into HDD 
-        if(vi_hdd_command(throttle) == HDD_COMMAND_FAILURE)
+        if(vi_hdd_command(HDD_CHOICE, throttle) == HDD_COMMAND_FAILURE)
             return PID_EXPERIMENT_FAILURE;
     }
 

--- a/control/experiment/determination_experiment.c
+++ b/control/experiment/determination_experiment.c
@@ -3,6 +3,10 @@
 #include "adcs_math/vector.h"
 #include "adcs_math/sensors.h"
 
+//TODO: MAG, HDD alternation?
+#define MAG_CHOICE MAG1
+#define HDD_CHOICE HDD1
+
 
 determination_exp_status determination_experiment()
 {
@@ -13,7 +17,7 @@ determination_exp_status determination_experiment()
     vec3 sun;
 
     vi_get_epoch(&year, &month, &day, &hour, &minute, &second);
-    vi_get_mag(&mag.x, &mag.y, &mag.z);
+    vi_get_mag(MAG_CHOICE, &mag.x, &mag.y, &mag.z);
     
     //TODO: default values for now, waiting for sun sensors to implement get_sun
     sun.x = 0;
@@ -41,7 +45,7 @@ determination_exp_status determination_experiment()
     {
         vi_delay_ms(100);
         vi_get_epoch(&year, &month, &day, &hour, &minute, &second);
-        vi_get_mag(&mag.x, &mag.y, &mag.z);
+        vi_get_mag(MAG_CHOICE, &mag.x, &mag.y, &mag.z);
         // default values for now, waiting for sun sensors to implement get_sun
         sun.x = 0;
         sun.y = 0;
@@ -62,7 +66,7 @@ determination_exp_status determination_experiment()
         //PLug it into the control function
         double throttle = PID_command(target, zrotation, curr_millis, &controller);
         //Take output and plug it into HDD 
-        if(vi_hdd_command(throttle) == HDD_COMMAND_FAILURE)
+        if(vi_hdd_command(HDD_CHOICE, throttle) == HDD_COMMAND_FAILURE)
             return DETERMINATION_EXPERIMENT_FAILURE;
         prevAttitude = currAttitude;
         prev_millis = curr_millis;

--- a/control/experiment/determination_experiment.h
+++ b/control/experiment/determination_experiment.h
@@ -5,6 +5,7 @@
 #include "control/PID/PID.h"
 #include "virtual_intellisat.h"
 
+
 typedef enum determination_experiment{
     DETERMINATION_EXPERIMENT_SUCCESS,
     DETERMINATION_EXPERIMENT_FAILURE

--- a/control/experiment/ramp_experiment.c
+++ b/control/experiment/ramp_experiment.c
@@ -1,5 +1,9 @@
+#include "control/experiment/ramp_experiment.h"
+#include "virtual_intellisat.h"
 
-#include "ramp_experiment.h"
+//TODO: HDD alternation?
+#define HDD_CHOICE HDD1
+
 
 run_ramp_experiment_status ramp_experiment(){
 
@@ -25,13 +29,11 @@ run_ramp_experiment_status ramp_experiment(){
 
         double command = linear_ramp_command(ti , &controller);
         
-        command_status = vi_hdd_command(command);
+        command_status = vi_hdd_command(HDD_CHOICE, command);
         if (command_status == HDD_COMMAND_FAILURE){
             return RUN_RAMP_EXPERIMENT_FAILURE;
         }
-
     }
     
     return RUN_RAMP_EXPERIMENT_SUCCESS;
-    
 }

--- a/control/experiment/ramp_experiment.h
+++ b/control/experiment/ramp_experiment.h
@@ -1,4 +1,3 @@
-
 #ifndef RAMP_EXPERIMENT_H
 #define RAMP_EXPERIMENT_H
 
@@ -6,11 +5,13 @@
 #include "virtual_intellisat.h"
 #include "control/ramp/ramp.h"
 
+
 typedef enum {
     RUN_RAMP_EXPERIMENT_SUCCESS,
     RUN_RAMP_EXPERIMENT_FAILURE
 } run_ramp_experiment_status;
 
 run_ramp_experiment_status ramp_experiment();
+
 
 #endif

--- a/virtual_intellisat.h
+++ b/virtual_intellisat.h
@@ -19,6 +19,65 @@
 #ifndef VIRTUAL_INTELLISAT_H
 #define VIRTUAL_INTELLISAT_H
 
+
+typedef enum {
+    MAG1,
+    MAG2
+} vi_MAG;
+
+typedef enum {
+    IMU1,
+    IMU2
+} vi_IMU;
+
+typedef enum {
+    HDD1,
+    HDD2
+} vi_HDD;
+
+typedef enum {
+//Start CSS
+	CSS_PX1,
+	CSS_PX2,
+	
+	CSS_NX1,
+	CSS_NX2,
+	
+	CSS_PY1,
+	CSS_PY2,
+
+	CSS_NY1,
+	CSS_NY2,
+	
+	CSS_PZ1,
+	CSS_PZ2,
+	
+	CSS_NZ1,
+	CSS_NZ2,
+//End CSS
+//Start MAG
+	MAG1_X,
+	MAG2_X,
+	
+	MAG1_Y,
+	MAG2_Y,
+	
+	MAG1_Z,
+	MAG2_Z,
+//End MAG
+//Start IMU
+	IMU1_X,
+	IMU2_X,
+	
+	IMU1_Y,
+	IMU2_Y,
+	
+	IMU1_Z,
+	IMU2_Z,
+//End IMU
+} vi_sensor;
+
+
 typedef enum {
     GET_EPOCH_SUCCESS,
     GET_EPOCH_FAILURE
@@ -41,7 +100,6 @@ vi_get_epoch(
 );
 
 
-
 typedef enum {
     GET_CURR_MILLIS_SUCCESS,
     GET_CURR_MILLIS_FAILURE
@@ -61,7 +119,6 @@ vi_get_curr_millis(
 );
 
 
-
 typedef enum {
     GET_ANGVEL_SUCCESS,
     GET_ANGVEL_FAILURE
@@ -69,6 +126,7 @@ typedef enum {
 
 /**@brief Retrieve angular velocity data from the IMU.
  *
+ * @param imu Which inertial measurement unit to read from.
  * @param angvel_x,angvel_y,angvel_z Return-by-reference ptrs.
  *
  * The sign of the angular velocity values must adhere to the
@@ -78,11 +136,11 @@ typedef enum {
  */
 vi_get_angvel_status
 vi_get_angvel(
+    vi_IMU imu,
     double *angvel_x, 
     double *angvel_y,
     double *angvel_z
 );
-
 
 
 typedef enum {
@@ -92,6 +150,7 @@ typedef enum {
 
 /**@brief Send a throttle command to the HDD.
  *
+ * @param hdd Which HDD to command.
  * @param throttle The desired throttle in the range [-1.0, 1.0].
  *
  * Intellisat must check these bounds for the input.
@@ -104,61 +163,15 @@ typedef enum {
  */
 vi_hdd_command_status
 vi_hdd_command(
+    vi_HDD hdd,
     double throttle
 );
 
-
-
-typedef enum{
-//Start CSS
-	CSS_PX1,
-	CSS_PX2,
-	
-	CSS_NX1,
-	CSS_NX2,
-	
-	CSS_PY1,
-	CSS_PY2,
-
-	CSS_NY1,
-	CSS_NY2,
-	
-	CSS_PZ1,
-	CSS_PZ2,
-	
-	CSS_NZ1,
-	CSS_NZ2,
-//End CSS
-	
-//Start MAG
-	MAG1_X,
-	MAG2_X,
-	
-	MAG1_Y,
-	MAG2_Y,
-	
-	MAG1_Z,
-	MAG2_Z,
-//End MAG
-	
-	
-//Start IMU
-	IMU1_X,
-	IMU2_X,
-	
-	IMU1_Y,
-	IMU2_Y,
-	
-	IMU1_Z,
-	IMU2_Z,
-//End IMU
-} vi_sensors;
 
 typedef enum{
 	GET_CONSTANT_SUCCESS,
 	GET_CONSTANT_FAILURE
 } vi_get_constant_status;
-
 
 /**@brief Get the current calibration values for a sensor.
  *
@@ -171,7 +184,7 @@ typedef enum{
  */
 vi_get_constant_status
 vi_get_sensor_calibration(
-	vi_sensors sensor, 
+	vi_sensor sensor, 
 	float *offset,
 	float *scalar,
 	float *filter_constant
@@ -206,7 +219,7 @@ vi_get_TLE(
  */
 vi_get_constant_status
 vi_get_sensor_status(
-	vi_sensors sensor,
+	vi_sensor sensor,
 	int *sensor_status
 );
 
@@ -218,12 +231,14 @@ typedef enum {
 
 /**@brief Get the current magnetic field value.
  *
+ * @param mag Which magnetometer to read from.
  * @param mag_x,mag_y,mag_z The magnetic field vector.
  *
  * @return vi_get_mag_status A return code, success/failure.
  */
 vi_get_mag_status
 vi_get_mag(
+    vi_MAG mag,
 	double *mag_x,
 	double *mag_y,
 	double *mag_z
@@ -247,24 +262,32 @@ vi_delay_ms(
 );
 
 
-/**@brief printing string
+/**@brief Print a string.
  *
- * @param string to print
+ * @param The string to print.
  *
+ * @return Void.
  */
-
 void vi_print (const char*);
+
 
 typedef enum {
 	VI_CONTROL_COIL_SUCCESS,
 	VI_CONTROL_COIL_FAILURE
 } vi_control_coil_status;
 
+/**@brief Set the coils' dipole vector.
+ *
+ * @param command_x,command_y,command_z The dipole vector.
+ *
+ * @return vi_control_coil_status A return code, success/failure.
+ */
 vi_control_coil_status 
 vi_control_coil(
 	double command_x,
 	double command_y,
 	double command_z
 );
+
 
 #endif//VIRTUAL_INTELLISAT_H


### PR DESCRIPTION
Because we have two of each sensor and actuator (besides the CSSs), virtual intellisat functions that read or command them must specify which sensor/actuator the read/command refers to.

Add an argument to each vi function for sensor/actuator choice.